### PR TITLE
Fix people holding hands

### DIFF
--- a/add_glyphs.py
+++ b/add_glyphs.py
@@ -228,7 +228,10 @@ def get_rtl_seq(seq):
 
   rev_seq = list(seq)
   rev_seq.reverse()
-  for i in xrange(1, len(rev_seq)):
+  starts_with_fp = is_fitzpatrick(rev_seq[0])
+  for i in range(1, len(rev_seq)):
+    if i == 2 and starts_with_fp:
+      continue
     if is_fitzpatrick(rev_seq[i-1]):
       tmp = rev_seq[i]
       rev_seq[i] = rev_seq[i-1]

--- a/emoji_aliases.txt
+++ b/emoji_aliases.txt
@@ -13,3 +13,23 @@ fe82b;unknown_flag # no name -> no name
 1f1f2_1f1eb;1f1eb_1f1f7 # MF -> FR
 1f1f8_1f1ef;1f1f3_1f1f4 # SJ -> NO
 1f1fa_1f1f2;1f1fa_1f1f8 # UM -> US
+
+# People holding hands
+# Adds sequence for emoji that also have dedicated Unicode values
+1f468_1f3fb_200d_1f91d_200d_1f468_1f3fb;1f46c_1f3fb
+1f468_1f3fc_200d_1f91d_200d_1f468_1f3fc;1f46c_1f3fc
+1f468_1f3fd_200d_1f91d_200d_1f468_1f3fd;1f46c_1f3fd
+1f468_1f3fe_200d_1f91d_200d_1f468_1f3fe;1f46c_1f3fe
+1f468_1f3ff_200d_1f91d_200d_1f468_1f3ff;1f46c_1f3ff
+
+1f469_1f3fb_200d_1f91d_200d_1f468_1f3fb;1f46b_1f3fb
+1f469_1f3fc_200d_1f91d_200d_1f468_1f3fc;1f46b_1f3fc
+1f469_1f3fd_200d_1f91d_200d_1f468_1f3fd;1f46b_1f3fd
+1f469_1f3fe_200d_1f91d_200d_1f468_1f3fe;1f46b_1f3fe
+1f469_1f3ff_200d_1f91d_200d_1f468_1f3ff;1f46b_1f3ff
+
+1f469_1f3fb_200d_1f91d_200d_1f469_1f3fb;1f46d_1f3fb
+1f469_1f3fc_200d_1f91d_200d_1f469_1f3fc;1f46d_1f3fc
+1f469_1f3fd_200d_1f91d_200d_1f469_1f3fd;1f46d_1f3fd
+1f469_1f3fe_200d_1f91d_200d_1f469_1f3fe;1f46d_1f3fe
+1f469_1f3ff_200d_1f91d_200d_1f469_1f3ff;1f46d_1f3ff


### PR DESCRIPTION
Because of two errors, half of the "people holding hands" emoji sequences are broken:

<img width="768" alt="image" src="https://user-images.githubusercontent.com/4570664/66105762-9d77d780-e5bc-11e9-91be-187cb52409e1.png">

The first commit addresss a bug in the code generating rtl sequences, the second adds aliases for the remaining emoji. The result is now:

<img width="399" alt="image" src="https://user-images.githubusercontent.com/4570664/66105820-c5ffd180-e5bc-11e9-9c10-acaf913b35bc.png">
