### PR TITLE
Makefile: make check_sequence a order-only prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,8 +206,8 @@ $(COMPRESSED_DIR)/%.png: $(QUANTIZED_DIR)/%.png | check_tools $(COMPRESSED_DIR)
 	@rm -f "$@"
 	ttx "$<"
 
-$(EMOJI).ttf: check_sequence $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
-	$(ALL_COMPRESSED_FILES) | check_tools
+$(EMOJI).ttf: $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
+	$(ALL_COMPRESSED_FILES) | check_sequence check_tools
 
 	@$(PYTHON) $(EMOJI_BUILDER) $(SMALL_METRICS) -V $< "$@" "$(COMPRESSED_DIR)/emoji_u"
 	@$(PYTHON) $(PUA_ADDER) "$@" "$@-with-pua"


### PR DESCRIPTION
The Makefile rule for the `$(EMOJI).ttf` target passes the first
prerequisite to the emoji_builder python script using the $< automatic
Makefile variable. For this reason, the first prerequisite of this
target must be `$(EMOJI).tmpl.ttf`. Otherwise the following
error message is emitted:

	FileNotFoundError: [Errno 2] No such file or directory: 'check_sequence'

This commit moves the check_sequence prerequisite to the order-only
prerequisites of where it actually belongs as the target itself should
not be updated if check_sequence is executed.