### PR TITLE
Add missing build dep & fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Building Noto Color Emoji requires:
 - [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
 - [pngquant](https://pngquant.org/)
 - [zopflipng](https://github.com/google/zopfli)
+- [cairo](https://www.cairographics.org/)
 
 ## Building NotoColorEmoji
 This project uses a virtual environment to manage dependencies. Use the following steps to get up and running:

--- a/third_party/region-flags/README.md
+++ b/third_party/region-flags/README.md
@@ -56,7 +56,7 @@ region.
 - The script `download-wp.py` downloads missing flags from Wikipedia and generating
 optimized SVG and PNG versions.
 
-You can use the [waveflag script from the Noto fonts project](https://code.google.com/p/noto/source/browse/color_emoji/waveflag.c)
+You can use the [waveflag script from the Noto fonts project](../../waveflag.c)
 to _wave_ PNG flags.
 
 # Requirements


### PR DESCRIPTION
The changes are pretty simple and self-explanatory.

### Why not include all the dependencies that are missing?
There are some other dependencies that are not stated (such as `make`) but these are easy to find out, however cairo is not, so for now I've only added cairo.