### PR TITLE
Fix vert_x_bearing to integer type

### DIFF
--- a/third_party/color_emoji/emoji_builder.py
+++ b/third_party/color_emoji/emoji_builder.py
@@ -123,7 +123,7 @@ class CBDT:
 			y_bearing = 127
 		advance = width
 
-		vert_x_bearing = - width / 2
+		vert_x_bearing = int (- width / 2)
 		vert_y_bearing = 0
 		vert_advance = height
 


### PR DESCRIPTION
At line 144:
  self.write (struct.pack ("BBbbBbbB",

vert_x_bearing was expected to be an integer.  Calculations is currently a double causing this to fail.