### PR TITLE
remove unsupported <text> element in emoji_u1f4b0.svg

### DIFF
--- a/svg/emoji_u1f4b0.svg
+++ b/svg/emoji_u1f4b0.svg
@@ -76,7 +76,6 @@
 </g>
 <g id="Layer_1_copy">
 	
-		<text transform="matrix(0.9998 0.0181 -0.0181 0.9998 -641.1694 100.3173)" style="fill:#6D4C41; font-family:'Helvetica-Bold'; font-size:70.0984px;">$</text>
 	<g>
 		
 			<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="90.7879" y1="52.2334" x2="90.7879" y2="52.2334" gradientTransform="matrix(0.9922 0.1244 -0.1244 0.9922 -16.4787 -22.858)">


### PR DESCRIPTION
An unsupported and apparently unused `<text>` element sneaked in emoji_u1f4b0.svg unnoticed along with the latest design changes (65dc359a).
This PR removes the offending line.