### PR TITLE
fix Makefile whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ SELECTED_FLAGS = AC AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ \
 	XK \
 	YE YT \
 	ZA ZM ZW \
-        GB-ENG GB-SCT GB-WLS
+	GB-ENG GB-SCT GB-WLS
 
 ifeq (,$(shell which $(ZOPFLIPNG)))
   ifeq (,$(wildcard $(ZOPFLIPNG)))


### PR DESCRIPTION
This replaces spaces with tabs for consistency with other country codes.